### PR TITLE
Adding cmake to requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Running the script will:
 - Ruby 2.1.x, bundler
 - Xcode and command line tools.  Tested with Xcode 7.1.
 - curl, tar, unzip, git (seems to be installed by default on OS X)
+- cmake (links: <a href="http://brewformulas.org/Cmake" target="_blank">homebrew</a> | <a href="https://cmake.org/install/" target="_blank">source</a>)
 
 As of this writing, the latest openalpr commit on the master branch was `eecd41e097534f84e2669da24d4aed4bf75a1132`
 


### PR DESCRIPTION
I had trouble building openalpr.framework from the `bundle exec` step. Upon inspecting the failing command that was being passed to `utils.rb`, I found that the build was failing due to me not having cmake installed. I've added cmake to the requirements list in `README.md`.

Thanks for your work with openalpr @twelve17!

...

For reference, here is the command that was failing: `cmake -GXcode -DIOS_PLATFORM=OS -DLeptonica_FRAMEWORK_PATH=/Users/bogdan/Code/Misc/openalpr-ios/output/leptonica.framework -DTesseract_FRAMEWORK_PATH=/Users/bogdan/Code/Misc/openalpr-ios/output/tesseract.framework -DOpenCV_FRAMEWORK_PATH=/Users/bogdan/Code/Misc/openalpr-ios/output/opencv2.framework -DOpenCV_VERSION=3.0.0 -DOpenCV_VERSION_MAJOR=3 -DCMAKE_TOOLCHAIN_FILE=/Users/bogdan/Code/Misc/openalpr-ios/etc/cmake/Toolchains/iOS.cmake /Users/bogdan/Code/Misc/openalpr-ios/work/openalpr/src 2>&1`